### PR TITLE
Re-architecting spiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://travis-ci.org/mtlynch/ketohub_raw_spider.svg?branch=master)](https://travis-ci.org/mtlynch/ketohub_raw_spider)
 [![Coverage Status](https://coveralls.io/repos/github/mtlynch/ketohub_raw_spider/badge.svg?branch=master)](https://coveralls.io/github/mtlynch/ketohub_raw_spider?branch=master)
 
-To run spider from the command line:
+To run the spiders:
 
 ```bash
-scrapy crawl ketoconnect_raw_content -s DOWNLOAD_ROOT=downloads/
-scrapy crawl ruled_me_raw_content -s DOWNLOAD_ROOT=downloads/
+scrapy crawl ketoconnect -s DOWNLOAD_ROOT=downloads/
+scrapy crawl ruled-me -s DOWNLOAD_ROOT=downloads/
 ```

--- a/ketohub/images.py
+++ b/ketohub/images.py
@@ -1,0 +1,6 @@
+import urllib
+
+
+def download_data(url):
+    image_handle = urllib.urlopen(url)
+    return image_handle.read()

--- a/ketohub/persist.py
+++ b/ketohub/persist.py
@@ -21,16 +21,16 @@ class ContentSaver(object):
         self._root = root
         self._write_file_fn = write_file_fn
 
-    def save_metadata(self, metadata):
+    def save_metadata(self, key, metadata):
         self._write_file_fn(
-            self._output_path('metadata.json'),
+            self._output_path(key, 'metadata.json'),
             json.dumps(metadata, indent=4, separators=(',', ':')))
 
-    def save_recipe_html(self, recipe_html):
-        self._write_file_fn(self._output_path('index.html'), recipe_html)
+    def save_recipe_html(self, key, recipe_html):
+        self._write_file_fn(self._output_path(key, 'index.html'), recipe_html)
 
-    def save_main_image(self, main_image_data):
-        self._write_file_fn(self._output_path('main.jpg'), main_image_data)
+    def save_main_image(self, key, main_image_data):
+        self._write_file_fn(self._output_path(key, 'main.jpg'), main_image_data)
 
-    def _output_path(self, filename):
-        return os.path.join(self._root, filename)
+    def _output_path(self, key, filename):
+        return os.path.join(self._root, key, filename)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,22 @@
+import io
+import unittest
+
+import mock
+
+from ketohub import images
+
+
+class ImagesTest(unittest.TestCase):
+
+    def setUp(self):
+        mock_urlopen = mock.patch(
+            'ketohub.images.urllib.urlopen', autospec=True)
+        self.addCleanup(mock_urlopen.stop)
+        self.urlopen_patch = mock_urlopen.start()
+
+    def test_download_succeeds_when_server_is_ok(self):
+        self.urlopen_patch.return_value = io.BytesIO('dummy image data')
+        self.assertEqual(
+            images.download_data('http://mock.com/image.jpg'),
+            'dummy image data')
+        self.urlopen_patch.assert_called_once_with('http://mock.com/image.jpg')

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -11,30 +11,27 @@ class PersistTest(unittest.TestCase):
         self.mock_write_to_file_fn = mock.Mock()
 
     def test_save_recipe_html_saves_to_correct_file(self):
-        saver = persist.ContentSaver('downloads/foo',
-                                     self.mock_write_to_file_fn)
-        saver.save_recipe_html('<html>Mock HTML</html>')
+        saver = persist.ContentSaver('downloads', self.mock_write_to_file_fn)
+        saver.save_recipe_html('foo', '<html>Mock HTML</html>')
 
         self.mock_write_to_file_fn.assert_has_calls([
             mock.call('downloads/foo/index.html', '<html>Mock HTML</html>'),
         ])
 
     def test_save_main_image_saves_to_correct_file(self):
-        saver = persist.ContentSaver('downloads/foo',
-                                     self.mock_write_to_file_fn)
-        saver.save_main_image('dummy image data')
+        saver = persist.ContentSaver('downloads', self.mock_write_to_file_fn)
+        saver.save_main_image('bar', 'dummy image data')
 
         self.mock_write_to_file_fn.assert_has_calls([
-            mock.call('downloads/foo/main.jpg', 'dummy image data'),
+            mock.call('downloads/bar/main.jpg', 'dummy image data'),
         ])
 
     def test_save_metadata_saves_to_correct_file(self):
-        saver = persist.ContentSaver('downloads/foo',
-                                     self.mock_write_to_file_fn)
-        saver.save_metadata({'dummy_key': 'dummy value'})
+        saver = persist.ContentSaver('downloads', self.mock_write_to_file_fn)
+        saver.save_metadata('baz', {'dummy_key': 'dummy value'})
 
         self.mock_write_to_file_fn.assert_has_calls([
-            mock.call('downloads/foo/metadata.json', """
+            mock.call('downloads/baz/metadata.json', """
 {
     "dummy_key":"dummy value"
 }""".strip()),

--- a/tests/test_spiders.py
+++ b/tests/test_spiders.py
@@ -1,114 +1,35 @@
-import datetime
-import io
 import unittest
 
-import mock
 from scrapy import http
 
 from ketohub import spiders
 
 
-class SpiderBaseTest(unittest.TestCase):
-    """Test case for the raw_content spider."""
+class FindKetoConnectImageUrlTest(unittest.TestCase):
 
-    def setUp(self):
-        mock_urlopen = mock.patch(
-            'ketohub.spiders.urllib.urlopen', autospec=True)
-        self.addCleanup(mock_urlopen.stop)
-        self.urlopen_patch = mock_urlopen.start()
-
-        self.mock_start_scrape_time = datetime.datetime(
-            year=2017, month=1, day=2, hour=3, minute=4, second=5)
-        mock_datetime = mock.patch('ketohub.spiders.datetime.datetime')
-        self.addCleanup(mock_datetime.stop)
-        datetime_patch = mock_datetime.start()
-        datetime_patch.utcnow.return_value = self.mock_start_scrape_time
-
-        mock_content_saver = mock.patch('ketohub.spiders.persist.ContentSaver')
-        self.addCleanup(mock_content_saver.stop)
-        self.content_saver_patch = mock_content_saver.start()
-        self.mock_saver = mock.Mock()
-        self.content_saver_patch.return_value = self.mock_saver
-
-        mock_get_recipe_main_image = mock.patch(
-            'ketohub.spiders.SpiderBase._get_recipe_main_image_url')
-        self.addCleanup(mock_get_recipe_main_image.stop)
-        self.get_image_patch = mock_get_recipe_main_image.start()
-
-    def test_download_recipe_contents_with_a_simple_response(self):
-        """Tests that download_recipe_contents works as expected for a simple response."""
-        response = http.TextResponse(
-            url='https://www.foo.com',
-            request=http.Request('https://www.foo.com'),
-            body='<html></html>')
-
-        self.get_image_patch.return_value = 'https://mock.com/test_image.jpg'
-        self.urlopen_patch.return_value = io.BytesIO('dummy image data')
-        spider = spiders.SpiderBase()
-        spider.download_recipe_contents(response)
-
-        self.content_saver_patch.assert_called_once_with(
-            'download_output/20170102/030405Z/foo-com')
-        self.mock_saver.save_recipe_html.assert_called_once_with(
-            '<html></html>')
-        self.mock_saver.save_metadata.assert_called_once_with({
-            'url':
-            'https://www.foo.com',
-        })
-        self.mock_saver.save_main_image.assert_called_once_with(
-            'dummy image data')
-
-        self.urlopen_patch.assert_called_with('https://mock.com/test_image.jpg')
-
-    def test_download_recipe_contents_with_an_empty_response(self):
-        """Tests that download recipe contents raises an error on an empty response."""
-        response = http.TextResponse(
-            url='https://www.foo.com',
-            request=http.Request('https://www.foo.com'),
-            body='')
-
-        self.get_image_patch.side_effect = IndexError
-        spider = spiders.SpiderBase()
-
-        with self.assertRaises(spiders.UnexpectedResponse):
-            spider.download_recipe_contents(response)
+    def test_finds_correct_image_on_simple_page(self):
+        self.assertEqual(
+            spiders.find_ketoconnect_image_url(
+                http.TextResponse(
+                    url='https://www.foo.com',
+                    request=http.Request('https://www.foo.com'),
+                    body="""
+                    <html>
+                      <img src="images/foo.jpg" />
+                      <img src="images/correct_image.jpg" />
+                    </html>""")), 'images/correct_image.jpg')
 
 
-class KetoConnectSpiderTest(SpiderBaseTest):
-    """Test case for the ketoconnect_raw_content spider."""
+class FindRuledMeImageUrlTest(unittest.TestCase):
 
-    def test_get_recipe_main_image_url_returns_second_image(self):
-        """Tests that the correct second image is extracted."""
-        file_content = (
-            "<html><img src='images/wrong_image.jpg'><img src='images/right_image.jpg'></html>"
-        )
-
-        response = http.TextResponse(
-            url='https://www.foo.com',
-            request=http.Request('https://www.foo.com'),
-            body=file_content)
-
-        spider = spiders.KetoConnectSpider()
-        spider.download_recipe_contents(response)
-
-        self.urlopen_patch.assert_called_with('images/right_image.jpg')
-
-
-class RuledMeSpiderTest(SpiderBaseTest):
-    """Test case for the ruled_me_raw_content spider."""
-
-    def test_get_recipe_main_image_url_returns_first_image(self):
-        """Tests that the first image location is extracted."""
-        file_content = (
-            "<html><img src='images/right_image.jpg'><img src='images/wrong_image.jpg'></html>"
-        )
-
-        response = http.TextResponse(
-            url='https://www.foo.com',
-            request=http.Request('https://www.foo.com'),
-            body=file_content)
-
-        spider = spiders.RuledMeSpider()
-        spider.download_recipe_contents(response)
-
-        self.urlopen_patch.assert_called_once_with('images/right_image.jpg')
+    def test_finds_correct_image_on_simple_page(self):
+        self.assertEqual(
+            spiders.find_ruled_me_image_url(
+                http.TextResponse(
+                    url='https://www.foo.com',
+                    request=http.Request('https://www.foo.com'),
+                    body="""
+                    <html>
+                      <img src="images/correct_image.jpg" />
+                      <img src="images/foo.jpg" />
+                    </html>""")), 'images/correct_image.jpg')


### PR DESCRIPTION
Pulling functionality out of the Spiders classes to make it easier to test.
Now spiders are just dumb wrappers and most of the work is delegated to the
CallbackHandler, which in turn delegates most work to smaller modules.