### PR TITLE
Removing logic for persisting recipe images

### DIFF
--- a/ketohub/persist.py
+++ b/ketohub/persist.py
@@ -29,8 +29,5 @@ class ContentSaver(object):
     def save_recipe_html(self, key, recipe_html):
         self._write_file_fn(self._output_path(key, 'index.html'), recipe_html)
 
-    def save_main_image(self, key, main_image_data):
-        self._write_file_fn(self._output_path(key, 'main.jpg'), main_image_data)
-
     def _output_path(self, key, filename):
         return os.path.join(self._root, key, filename)

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -18,14 +18,6 @@ class PersistTest(unittest.TestCase):
             mock.call('downloads/foo/index.html', '<html>Mock HTML</html>'),
         ])
 
-    def test_save_main_image_saves_to_correct_file(self):
-        saver = persist.ContentSaver('downloads', self.mock_write_to_file_fn)
-        saver.save_main_image('bar', 'dummy image data')
-
-        self.mock_write_to_file_fn.assert_has_calls([
-            mock.call('downloads/bar/main.jpg', 'dummy image data'),
-        ])
-
     def test_save_metadata_saves_to_correct_file(self):
         saver = persist.ContentSaver('downloads', self.mock_write_to_file_fn)
         saver.save_metadata('baz', {'dummy_key': 'dummy value'})


### PR DESCRIPTION
Raw spider no longer saves images.